### PR TITLE
Fixed a missing trailing slash

### DIFF
--- a/modules/services/unix/http/phish_me_website/manifests/apache.pp
+++ b/modules/services/unix/http/phish_me_website/manifests/apache.pp
@@ -10,7 +10,7 @@ class phish_me_website::apache {
 
   apache::vhost { 'accountingnow.com':
     port    => $port,
-    docroot => '/var/www/accountingnow',
+    docroot => '/var/www/accountingnow/',
     notify => Tidy['pws remove default site'],
   }
 


### PR DESCRIPTION
Fixes the following error when provisioning VM's:
```
Error: Duplicate declaration: File[/var/www/accountingnow] is already declared in file /tmp/vagrant-puppet/modules-2623f1aee4ddcc04fb208aea00ed53cd/phish_me_website/manifests/install.pp:11; cannot redeclare at /tmp/vagrant-puppet/modules-2623f1aee4ddcc04fb208aea00ed53cd/apache/manifests/vhost.pp:272
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
Non-zero exit status...
Error provisioning VMs, destroying VMs and exiting SecGen.
```